### PR TITLE
Add is_loaded property to lazy proxies

### DIFF
--- a/src/lazyshell/core.py
+++ b/src/lazyshell/core.py
@@ -142,6 +142,12 @@ class _LazyModuleProxy:
         state = "loaded" if self._obj is not _UNSET else "pending"
         return f"<lazyshell.Proxy {self._spec.path} ({state})>"
 
+    @property
+    def is_loaded(self) -> bool:
+        """Return ``True`` if the underlying object has been imported."""
+
+        return self._obj is not _UNSET
+
 
 def _parse_specs(modules: Iterable[str | Tuple[str, str]]) -> Iterable[_ImportSpec]:
     for mod in modules:

--- a/tests/test_lazyshell.py
+++ b/tests/test_lazyshell.py
@@ -1,6 +1,6 @@
 from src.lazyshell import shell_import
 import pytest
-#import xgboost as xgb
+
 
 def test_single_module():
     math = shell_import("math")
@@ -27,7 +27,9 @@ def test_sink_proxy():
     assert bool(missing)
     assert missing.foo.bar() is None
 
-def test_lazy():
-    xgb = shell_import('xgboost')
+def test_is_loaded_property():
+    math = shell_import("math")
+    assert not math.is_loaded
+    math.sqrt(4)
+    assert math.is_loaded
 
-    #print(xgb.__version__)


### PR DESCRIPTION
## Summary
- expose `is_loaded` property on `_LazyModuleProxy` for checking if the target object has been imported
- exercise new property in tests

## Testing
- `pytest -q` *(fails: test_submodule_class)*

------
https://chatgpt.com/codex/tasks/task_e_688bf405ba248328bbf6c63444ba4bdb