### PR TITLE
Improve README and fix lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,52 @@
-# lazy_shell
+# lazyshell
 
-Lazy, optional imports for Python projects. Declare your dependencies once and defer importing until needed. Missing packages can be handled gracefully using sink proxies.
+Lazy optional imports for Python projects. `shell_import` lets you declare optional dependencies once and load them on first use. Missing packages can degrade gracefully using **sink** proxies so your code keeps running.
+
+## Installation
+
+```bash
+pip install lazyshell
+```
+
+Supports Python 3.9 and newer and has no runtime dependencies.
+
+## Quick start
+
+```python
+from lazyshell import shell_import
+
+# request multiple modules at once
+np, hass, missing = shell_import(
+    "numpy",
+    ("hass", "homeassistant.core"),
+    "not_installed",
+    sink=True,                      # return sink proxies for missing packages
+    sink_map={"hass.log": print},  # route hass.log -> print
+)
+
+# modules are imported on first use
+arr = np.arange(3)
+
+# sink proxies are truthy and return None by default
+missing.anything()  # -> None
+
+# override behaviour for a specific attribute
+hass.log("hello")  # prints "hello"
+```
+
+## Proxy behaviour
+
+* `bool(proxy)` is `False` until the real module or object is successfully imported.
+* Accessing an attribute or calling the proxy triggers the import.
+* If the import fails:
+  * with `sink=False` (default) a ``MissingPackage`` sentinel is returned and attribute access raises ``ImportError``.
+  * with `sink=True` a ``SinkProxy`` is returned. It is truthy, attribute access returns further sink proxies and method calls are no-ops unless a fallback is provided via ``set``.
+* The `.with_sink()` helper enables sink mode on creation; `.enable_sink()` enables it after a failed import.
+* Register fallbacks with `proxy.set("attr", value)` or via attribute proxies: `proxy.attr.set(value)`.
+* The `is_loaded` property reports whether the underlying import has occurred.
+
+Set the environment variable `LAZYSHELL_DEBUG=1` to get a one-time warning when a sink proxy is instantiated.
+
+## License
+
+lazyshell is distributed under the terms of the MIT License. See `LICENSE` for details.

--- a/src/lazyshell/core.py
+++ b/src/lazyshell/core.py
@@ -5,7 +5,7 @@ import os
 import threading
 import warnings
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterable, Tuple, Union
+from typing import Any, Callable, Dict, Tuple, Union
 
 __all__ = [
     "shell_import",


### PR DESCRIPTION
## Summary
- document project usage and behaviour in README
- clean unused import picked up by ruff

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c1b323b888328978c4467779473ce